### PR TITLE
Add mock AI response when no API key present

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@ This is the [assistant-ui](https://github.com/Yonom/assistant-ui) starter projec
 
 ## Getting Started
 
-First, add your OpenAI API key to `.env.local` file:
+First, add your OpenAI API key to `.env.local` file (optional):
 
 ```
 OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
+
+If no `OPENAI_API_KEY` is provided, the `/api/chat` endpoint returns a mock
+response so the UI can still be tested without connecting to OpenAI.
 
 Then, run the development server:
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,12 +1,30 @@
 import { openai } from "@ai-sdk/openai";
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
-import { streamText } from "ai";
+import { createDataStreamResponse, streamText } from "ai";
+import { formatDataStreamPart } from "@ai-sdk/ui-utils";
 
 // export const runtime = "edge";
 export const maxDuration = 30;
 
 export async function POST(req: Request) {
   const { messages, system, tools } = await req.json();
+
+  if (!process.env.OPENAI_API_KEY) {
+    return createDataStreamResponse({
+      async execute(writer) {
+        writer.write(
+          formatDataStreamPart(
+            "text",
+            "This is a mock response because no OPENAI_API_KEY was provided."
+          )
+        );
+        writer.write(
+          formatDataStreamPart("finish_message", { finishReason: "stop" })
+        );
+      },
+      onError: console.error,
+    });
+  }
 
   const result = streamText({
     model: openai("gpt-4o"),


### PR DESCRIPTION
## Summary
- return a mock response from `/api/chat` when `OPENAI_API_KEY` is missing
- mention mock behaviour in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842112cbf948331b368bb3c6085c8ae